### PR TITLE
Correct naming for case-sensitive FS

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,2 +1,2 @@
 
-window.Aran = require('Aran')
+window.Aran = require('aran')


### PR DESCRIPTION
On Linux the file 'Aran' and the file 'aran' are different.
